### PR TITLE
[FIX] Find boost/openssl libs for rpm

### DIFF
--- a/rpm-builder/Dockerfile
+++ b/rpm-builder/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:latest
 RUN mkdir /opt/rippled-rpm
 WORKDIR /opt/rippled-rpm
 
-RUN rpm -Uvh http://mirrors.ripple.com/ripple-repo-el7.rpm
+RUN rpm -Uvh https://mirrors.ripple.com/ripple-repo-el7.rpm
 RUN yum install -y --enablerepo=ripple-stable git rpm-sign rpmdevtools krb5-devel zlib-devel gcc gcc-c++ wget libstdc++-devel bzip2-devel python-devel libicu-devel chrpath scons protobuf-devel ripple-boost ripple-boost-devel ripple-openssl-devel openssl-devel ripple-boost-coroutine
 
 RUN mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
@@ -13,8 +13,12 @@ RUN ln -s /opt/ripple/boost/lib/* /lib64/
 RUN ln -s -f /opt/ripple/openssl/include/openssl/* /usr/include/openssl/
 RUN ln -s -f /opt/ripple/openssl/lib/*.so* /lib64/
 RUN ln -s -f /opt/ripple/openssl/lib/openssl /lib64/openssl
-RUN ln -s -f 1/opt/ripple/openssl/lib/pkgconfig/* /lib64/pkgconfig/
+RUN ln -s -f /opt/ripple/openssl/lib/pkgconfig/* /lib64/pkgconfig/
 RUN ldconfig
+
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py
+RUN pip install awscli
 
 COPY private.key ./
 

--- a/rpm-builder/build_rpm.sh
+++ b/rpm-builder/build_rpm.sh
@@ -25,6 +25,6 @@ rpmbuild -ba $1
 rpmsign --key-id="Ripple Release Engineering" --addsign ~/rpmbuild/RPMS/x86_64/*.rpm ~/rpmbuild/SRPMS/*.rpm
 
 # Upload a tar of the rpm and source rpm to s3
-tar -zvcf $RIPPLED_VERSION.tar.gz -C rpm . -C ../src .
+tar -zvcf $RIPPLED_VERSION.tar.gz -C ~/rpmbuild/RPMS/x86_64/ . -C ~/rpmbuild/SRPMS/ .
 
 aws s3 cp $RIPPLED_VERSION.tar.gz s3://rpm-builder-test

--- a/rpm-builder/rippled.service
+++ b/rpm-builder/rippled.service
@@ -3,8 +3,8 @@ Description=Ripple Daemon
 
 [Service]
 Type=simple
-ExecStart=/opt/ripple/bin/rippled --conf /opt/ripple/etc/rippled.cfg
-ExecStop=/opt/ripple/bin/rippled --conf /opt/ripple/etc/rippled.cfg stop
+ExecStart=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ripple/openssl/lib:/opt/ripple/boost/lib /opt/ripple/bin/rippled --conf /opt/ripple/etc/rippled.cfg
+ExecStop=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ripple/openssl/lib:/opt/ripple/boost/lib /opt/ripple/bin/rippled --conf /opt/ripple/etc/rippled.cfg stop
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Stop configuring LD_LIBRARY_PATH once rippled's SConstruct can use BOOST_ROOT and OPENSSL_ROOT for unix