### PR TITLE
Make systemd service configuration files non-overwrite (via %config(noreplace))

### DIFF
--- a/rpm-builder/rippled.spec
+++ b/rpm-builder/rippled.spec
@@ -62,8 +62,8 @@ chmod 755 /var/lib/rippled/
 %{_bindir}/rippled
 %{_bindir}/wrapper.sh
 %config(noreplace) %{_prefix}/etc/rippled.cfg
-/usr/lib/systemd/system/rippled.service
-/usr/lib/systemd/system-preset/50-rippled.preset
+%config(noreplace) /usr/lib/systemd/system/rippled.service
+%config(noreplace) /usr/lib/systemd/system-preset/50-rippled.preset
 %dir /var/log/rippled/
 %dir /var/lib/rippled/
 


### PR DESCRIPTION
**Intent**: Ensure that our RPM doesn't interfere with Chef (and any other) administration of startup and daemon services.

```
$ git diff HEAD~1
diff --git a/rpm-builder/rippled.spec b/rpm-builder/rippled.spec
index 3b190e7..3f5a2c3 100644
--- a/rpm-builder/rippled.spec
+++ b/rpm-builder/rippled.spec
@@ -62,8 +62,8 @@ chmod 755 /var/lib/rippled/
 %{_bindir}/rippled
 %{_bindir}/wrapper.sh
 %config(noreplace) %{_prefix}/etc/rippled.cfg
-/usr/lib/systemd/system/rippled.service
-/usr/lib/systemd/system-preset/50-rippled.preset
+%config(noreplace) /usr/lib/systemd/system/rippled.service
+%config(noreplace) /usr/lib/systemd/system-preset/50-rippled.preset
 %dir /var/log/rippled/
 %dir /var/lib/rippled/
```
 
Thanks! NOTE: This is untested, so please test well.

Cheers,
Jesse