### PR TITLE
[TASK] Use rippled --silent flag

### DIFF
--- a/rpm-builder/rippled.service
+++ b/rpm-builder/rippled.service
@@ -3,8 +3,7 @@ Description=Ripple Daemon
 
 [Service]
 Type=simple
-Environment="LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/ripple/openssl/lib:/opt/ripple/boost/lib"
-ExecStart=/opt/ripple/bin/wrapper.sh --conf /etc/opt/ripple/rippled.cfg
+ExecStart=/opt/ripple/bin/rippled --net --silent --conf /etc/opt/ripple/rippled.cfg
 ExecStop=/opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg stop
 Restart=no
 User=rippled


### PR DESCRIPTION
DEC-709
Modifying `LD_LIBRARY_PATH` is no longer necessary with static build