### PR TITLE
Install validator configuration script

### DIFF
--- a/rpm-builder/Dockerfile
+++ b/rpm-builder/Dockerfile
@@ -66,6 +66,7 @@ COPY rippled.service /root/rpmbuild/SOURCES/
 COPY 50-rippled.preset /root/rpmbuild/SOURCES/
 COPY update-rippled.sh /root/rpmbuild/SOURCES/
 COPY nofile_limit.conf /root/rpmbuild/SOURCES/
+COPY configure-validator.sh /root/rpmbuild/SOURCES/
 
 # Import rippled dev public keys
 COPY public-keys.txt ./

--- a/rpm-builder/configure-validator.sh
+++ b/rpm-builder/configure-validator.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if /opt/ripple/bin/rippled -q server_info | \
+  grep -q 'no response from server'
+then
+  echo "rippled server is not running"
+  exit 1
+fi
+
+# Check for validation key
+VALIDATION_PUBLIC_KEY=`/opt/ripple/bin/rippled server_info -q | \
+  python -c 'import json,sys;obj=json.load(sys.stdin); \
+  print obj["result"]["info"]["pubkey_validator"]'`
+
+if [  "$VALIDATION_PUBLIC_KEY" != "none" ]; then
+  echo "rippled already configured as a validator"
+  exit 1
+fi
+
+# Generate validation key
+VALIDATION_SEED=`/opt/ripple/bin/rippled validation_create -q | \
+  python -c 'import json,sys;obj=json.load(sys.stdin); \
+  print obj["result"]["validation_seed"]'`
+
+echo "
+[validation_seed]
+$VALIDATION_SEED
+" >> /etc/opt/ripple/rippled.cfg
+
+systemctl restart rippled.service
+
+# Wait for rippled to start up
+while /opt/ripple/bin/rippled -q server_info | \
+  grep -q 'no response from server'
+do
+  sleep 1
+done
+
+VALIDATION_PUBLIC_KEY=`/opt/ripple/bin/rippled server_info -q | \
+  python -c 'import json,sys;obj=json.load(sys.stdin); \
+  print obj["result"]["info"]["pubkey_validator"]'`
+
+if [  "$VALIDATION_PUBLIC_KEY" == "none" ]; then
+  echo "validator configuration failed"
+  exit 1
+fi
+
+cat << EOF
+Successfully configured rippled to run as a validating server.
+validation public key: $VALIDATION_PUBLIC_KEY
+validation seed: $VALIDATION_SEED <-- Keep this PRIVATE and save in a secure place
+EOF

--- a/rpm-builder/rippled.spec
+++ b/rpm-builder/rippled.spec
@@ -15,6 +15,7 @@ Source1:        rippled.service
 Source2:        50-rippled.preset
 Source3:        update-rippled.sh
 Source4:        nofile_limit.conf
+Source5:        configure-validator.sh
 
 BuildRequires:  scons boost-devel protobuf-devel openssl-devel
 
@@ -42,6 +43,7 @@ install -D %{SOURCE2} ${RPM_BUILD_ROOT}/usr/lib/systemd/system-preset/50-rippled
 install -D %{SOURCE3} ${RPM_BUILD_ROOT}%{_bindir}/update-rippled.sh
 install -d ${RPM_BUILD_ROOT}/etc/systemd/system/rippled.service.d/
 install -D %{SOURCE4} ${RPM_BUILD_ROOT}/etc/systemd/system/rippled.service.d/nofile_limit.conf
+install -D %{SOURCE5} ${RPM_BUILD_ROOT}%{_bindir}/configure-validator.sh
 
 install -d $RPM_BUILD_ROOT/var/log/rippled
 install -d $RPM_BUILD_ROOT/var/lib/rippled
@@ -64,6 +66,7 @@ chmod 755 /var/lib/rippled/
 %doc README.md LICENSE
 %{_bindir}/rippled
 %{_bindir}/update-rippled.sh
+%{_bindir}/configure-validator.sh
 %config(noreplace) %{_prefix}/etc/rippled.cfg
 %config(noreplace) /etc/opt/ripple/rippled.cfg
 %config(noreplace) %{_prefix}/etc/validators.txt
@@ -75,5 +78,8 @@ chmod 755 /var/lib/rippled/
 %dir /var/lib/rippled/
 
 %changelog
+* Fri Jun 03 2016 Brandon Wilson <bwilson@ripple.com>
+- Install configure-validator.sh
+
 * Thu Jun 02 2016 Brandon Wilson <bwilson@ripple.com>
 - Install validators.txt


### PR DESCRIPTION
configure-validator.sh will be installed by the rippled rpm
We will replace these steps with simply running the script:
https://ripple.com/build/rippled-setup/#validator-setup
