### PR TITLE
Update rippled.service - start rippled after network.target

### DIFF
--- a/rpm-builder/rippled.service
+++ b/rpm-builder/rippled.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ripple Daemon
+After=syslog.target network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
In some environments rippled fails to start up after reboot, because the network is not yet started. This should fix it.